### PR TITLE
Add monitor to Router model

### DIFF
--- a/lib/fog/sakuracloud/models/network/router.rb
+++ b/lib/fog/sakuracloud/models/network/router.rb
@@ -32,6 +32,10 @@ module Fog
           true
         end
 
+        def collect_monitor
+          service.collect_monitor_router(identity).body["Data"]
+        end
+
         def router_available?(network, router_id)
           until network.switches.find {|r| r.internet != nil && r.internet["ID"] == router_id}
             print '.'

--- a/lib/fog/sakuracloud/network.rb
+++ b/lib/fog/sakuracloud/network.rb
@@ -18,6 +18,7 @@ module Fog
       request      :list_routers
       request      :create_router
       request      :delete_router
+      request      :collect_monitor_router
       request      :list_switches
       request      :create_switch
       request      :delete_switch

--- a/lib/fog/sakuracloud/requests/network/collect_monitor_router.rb
+++ b/lib/fog/sakuracloud/requests/network/collect_monitor_router.rb
@@ -1,0 +1,37 @@
+# coding: utf-8
+
+module Fog
+  module Network
+    class SakuraCloud
+      class Real
+        def collect_monitor_router( id )
+          request(
+            :headers => {
+              'Authorization' => "Basic #{@auth_encode}"
+            },
+            :expects  => [200],
+            :method => 'GET',
+            :path => "#{Fog::SakuraCloud.build_endpoint(@api_zone)}/internet/#{id}/monitor"
+          )
+        end
+      end # Real
+
+      class Mock
+        def collect_monitor_router( id )
+          response = Excon::Response.new
+          response.status = 200
+          response.body = {
+            "Data"=>{
+              "2015-12-16T18:00:00+09:00"=>{
+                "In"=>500000,
+                "Out"=>70000000
+              }
+            },
+            "is_ok"=>true
+          }
+          response
+        end
+      end # Mock
+    end # SakuraCloud
+  end # Network
+end # Fog


### PR DESCRIPTION
# Purpose
fog-sakuracloud cannot get the network bandwidth statistics of router.

# Changes
- Implement `Fog::Network::SakuraCloud::Router#monitor` method.
http://developer.sakura.ad.jp/cloud/api/1.1/internet/#get_internet_internetid_monitor

Any thoughts?